### PR TITLE
fix: use portable shebang in go shim script

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -328,7 +328,7 @@ func SwitchVersion(version GoVersion) tea.Cmd {
 						return ErrMsg(fmt.Errorf("failed to create shim for %s: %v", binName, err))
 					}
 				} else {
-					shimContent := fmt.Sprintf(`#!/bin/bash
+					shimContent := fmt.Sprintf(`#!/usr/bin/env bash
 "%s" "$@"
 `, targetBin)
 					if err := os.WriteFile(shimPath, []byte(shimContent), 0755); err != nil {
@@ -369,4 +369,3 @@ func DeleteVersion(version GoVersion) tea.Cmd {
 		return DeleteCompleteMsg{Version: version.Version}
 	}
 }
-


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature
govm creates a shim script with hardcoded `/bin/bash` in the shebang line. This fails on NixOS and potentially other operating systems where bash is not located at `/bin/bash`, producing the error: `zsh: /home/fabric/.govm/shim/go: bad interpreter: /bin/bash: no such file or directory`

## Description of Changes:
- Changed shebang from `#!/bin/bash` to `#!/usr/bin/env bash` for better portability across different operating systems
- This ensures the shim script works on NixOS and other systems with non-standard paths

## Checklist
- [x] I have self-reviewed the changes being requested