### PR TITLE
Fix go windows version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 govm
 main
+.idea

--- a/internal/setup/model.go
+++ b/internal/setup/model.go
@@ -132,7 +132,7 @@ After adding to PATH, restart your terminal or run:
 			highlightStyle.Render(m.shimPath),
 			highlightStyle.Render(fmt.Sprintf("echo 'export PATH=\"$HOME/.govm/shim:$PATH\"' >> %s", shellConfigFile)),
 			shellConfigFile,
-			highlightStyle.Render(fmt.Sprintf("export PATH=\"$HOME/.govm/shim:$PATH\"")),
+			highlightStyle.Render("export PATH=\"$HOME/.govm/shim:$PATH\""),
 			highlightStyle.Render(fmt.Sprintf("source %s", shellConfigFile)))
 	}
 

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -1,9 +1,19 @@
 package utils
 
+import "runtime"
+
 type ErrMsg error
 
 type VersionsMsg []GoVersion
 
 type DeleteCompleteMsg struct {
 	Version string
+}
+
+var goBinary = "go"
+
+func init() {
+	if runtime.GOOS == "windows" {
+		goBinary = "go.exe"
+	}
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Because go binary for windos has a .exe extension, govm was failing to unzip to a correct folder

## Description of Changes:

- add a local variable for go binary
- change string "go" (binary name) to var goBinary

## Checklist

- [ X ] I have self-reviewed the changes being requested
